### PR TITLE
Add React Native concert monitor UI

### DIFF
--- a/ConcertGrabberApp/App.js
+++ b/ConcertGrabberApp/App.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import HomeScreen from './src/screens/HomeScreen';
+import SettingsScreen from './src/screens/SettingsScreen';
+import StatusScreen from './src/screens/StatusScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="Home" screenOptions={{ headerShown: false }}>
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="Settings" component={SettingsScreen} />
+        <Stack.Screen name="Status" component={StatusScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/ConcertGrabberApp/README.md
+++ b/ConcertGrabberApp/README.md
@@ -1,0 +1,26 @@
+# Concert Ticket Monitor & Auto-Grabber (React Native)
+
+This Expo-compatible React Native app demonstrates a simple UI for monitoring concert tickets.
+
+## Features
+
+- Home screen showing current monitoring state
+- Settings screen to configure monitoring
+- Status screen polling the server
+- Tailwind CSS styling via `nativewind`
+- Components from `shadcn/ui`
+
+## Development
+
+Install dependencies and run in Expo:
+
+```bash
+npm install
+npx expo start
+```
+
+The app expects backend endpoints:
+
+- `POST /api/startListening` – start monitoring
+- `GET /api/status` – fetch monitoring status
+```

--- a/ConcertGrabberApp/package.json
+++ b/ConcertGrabberApp/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "concert-ticket-monitor",
+  "version": "1.0.0",
+  "main": "App.js",
+  "private": true,
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.72.4",
+    "axios": "^1.4.0",
+    "nativewind": "^2.0.11",
+    "shadcn-ui": "^0.1.0",
+    "@react-navigation/native": "^6.1.3",
+    "@react-navigation/native-stack": "^6.9.12",
+    "react-native-safe-area-context": "^4.5.0"
+  }
+}

--- a/ConcertGrabberApp/src/screens/HomeScreen.js
+++ b/ConcertGrabberApp/src/screens/HomeScreen.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { Button, Card } from 'shadcn-ui';
+import { useNavigation } from '@react-navigation/native';
+
+export default function HomeScreen() {
+  const navigation = useNavigation();
+
+  return (
+    <View className="flex-1 bg-gray-100 p-4">
+      <Text className="text-2xl font-bold mb-4">Auto Concert Grabber</Text>
+      <Card className="p-4 rounded-xl shadow mb-4">
+        <Text className="text-lg">Monitoring for 张学友 in 上海</Text>
+        <Text className="text-sm text-gray-500 mt-1">Started: 2023-01-01 10:00</Text>
+        <Text className="text-sm text-gray-500 mt-1">Status: Not yet triggered</Text>
+      </Card>
+      <Button className="rounded-xl" onPress={() => navigation.navigate('Settings')}>
+        Go to Settings
+      </Button>
+    </View>
+  );
+}

--- a/ConcertGrabberApp/src/screens/SettingsScreen.js
+++ b/ConcertGrabberApp/src/screens/SettingsScreen.js
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import { View, Text } from 'react-native';
+import { Input, Button, Card, Toggle, Select } from 'shadcn-ui';
+import axios from 'axios';
+import { useNavigation } from '@react-navigation/native';
+
+export default function SettingsScreen() {
+  const navigation = useNavigation();
+  const [keyword, setKeyword] = useState('');
+  const [city, setCity] = useState('上海');
+  const [listenReturn, setListenReturn] = useState(false);
+  const [interval, setInterval] = useState('5');
+
+  const startListening = async () => {
+    try {
+      await axios.post('/api/startListening', {
+        keyword,
+        city,
+        listenReturn,
+        interval: Number(interval)
+      });
+      navigation.navigate('Status');
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <View className="flex-1 bg-gray-100 p-4">
+      <Text className="text-xl font-bold mb-4">Settings</Text>
+      <Card className="p-4 rounded-xl shadow mb-4">
+        <Text className="mb-2">Concert Keyword</Text>
+        <Input className="mb-4" value={keyword} onChangeText={setKeyword} placeholder="e.g. 张学友" />
+        <Text className="mb-2">City</Text>
+        <Select
+          className="mb-4"
+          selectedValue={city}
+          onValueChange={(val) => setCity(val)}
+          options={[{ label: '上海', value: '上海' }, { label: '北京', value: '北京' }]}
+        />
+        <View className="flex-row items-center mb-4">
+          <Toggle value={listenReturn} onValueChange={setListenReturn} />
+          <Text className="ml-2">Listen for 回流票</Text>
+        </View>
+        <Text className="mb-2">Frequency (seconds)</Text>
+        <Input keyboardType="numeric" value={interval} onChangeText={setInterval} className="mb-4" />
+        <Button onPress={startListening} className="rounded-xl">Start Listening</Button>
+      </Card>
+    </View>
+  );
+}

--- a/ConcertGrabberApp/src/screens/StatusScreen.js
+++ b/ConcertGrabberApp/src/screens/StatusScreen.js
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text } from 'react-native';
+import { Card, Button } from 'shadcn-ui';
+import axios from 'axios';
+import { useNavigation } from '@react-navigation/native';
+
+export default function StatusScreen() {
+  const navigation = useNavigation();
+  const [status, setStatus] = useState(null);
+
+  const fetchStatus = async () => {
+    try {
+      const { data } = await axios.get('/api/status');
+      setStatus(data);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  useEffect(() => {
+    fetchStatus();
+    const timer = setInterval(fetchStatus, 5000);
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <View className="flex-1 bg-gray-100 p-4">
+      <Text className="text-xl font-bold mb-4">Monitoring Status</Text>
+      <Card className="p-4 rounded-xl shadow mb-4">
+        {status ? (
+          <>
+            <Text className="mb-2">{status.message}</Text>
+            <Text className="mb-1">Listening: {status.listening ? 'Yes' : 'No'}</Text>
+            <Text className="mb-1">Grab Triggered: {status.triggered ? 'Yes' : 'No'}</Text>
+          </>
+        ) : (
+          <Text>Loading...</Text>
+        )}
+      </Card>
+      <Button onPress={() => navigation.navigate('Home')} className="rounded-xl">Back Home</Button>
+    </View>
+  );
+}

--- a/ConcertGrabberApp/tailwind.config.js
+++ b/ConcertGrabberApp/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './App.js',
+    './src/**/*.{js,jsx,ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- set up React Native project using Tailwind and shadcn/ui components
- implement navigation with Home, Settings and Status screens
- call backend endpoints to start listening and show status
- document how to run the mobile app

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_685f1cb5961c8320a8223648d8d88b0f